### PR TITLE
Correct licence reference in footer

### DIFF
--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -5,7 +5,7 @@
             SQL style guide
         </span> by
         <a xmlns:cc="http://creativecommons.org/ns#"
-           href="https://www.simonholywell.com/?utm_source=sqlstyle.guide&amp;utm_medium=link&amp;utm_campaign=footer-licence"
+           href="https://www.simonholywell.com/?utm_source=SQLServerIO&amp;utm_medium=link&amp;utm_campaign=footer-licence"
            property="cc:attributionName"
            rel="cc:attributionURL">
             Simon Holywell
@@ -15,8 +15,7 @@
             Creative CommonsAttribution-ShareAlike 4.0 International License</a>.
             <br />Based on a work at 
         <a xmlns:dct="http://purl.org/dc/terms/"
-           href="{{ site.url }}"
-           rel="dct:source">
-            {{ site.url }}</a>.
+           href="http://www.sqlstyle.guide"
+           rel="dct:source">www.sqlstyle.guide</a>.
     </p>
 </footer>


### PR DESCRIPTION
`{{ site.url }}` refers to the wrong place once you fork the project and host it somewhere else - think I might have to revise the original to hardcode this in as well.